### PR TITLE
make the flexmodel pass through additional attributes on the form_def…

### DIFF
--- a/src/Resources/xsd/flexmodel.xsd
+++ b/src/Resources/xsd/flexmodel.xsd
@@ -137,6 +137,7 @@
         </xs:sequence>
         <xs:attribute name='readonly' type='boolean' use='optional'/>
         <xs:attribute name='fieldtype' type='xs:string' use='optional'/>
+        <xs:anyAttribute processContents='skip'/>
     </xs:complexType>
 
     <!--


### PR DESCRIPTION
make the flexmodel pass through additional attributes on the form_defaults element

Like widget in this example

```xsd
<form_defaults widget="single_text" fieldtype='Symfony\Component\Form\Extension\Core\Type\BirthdayType'/>
```