### PR TITLE
Add type as attribute to inverse-reference in xsd

### DIFF
--- a/src/Resources/xsd/flexmodel.xsd
+++ b/src/Resources/xsd/flexmodel.xsd
@@ -79,6 +79,7 @@
         <xs:attribute name='name' type='xs:string' use='required'/>
         <xs:attribute name='object' type='xs:string' use='required'/>
         <xs:attribute name='field' type='xs:string' use='required'/>
+        <xs:attribute name='type' type='xs:string' use='required'/>
     </xs:complexType>
 
     <!--

--- a/src/Resources/xsd/flexmodel.xsd
+++ b/src/Resources/xsd/flexmodel.xsd
@@ -79,7 +79,7 @@
         <xs:attribute name='name' type='xs:string' use='required'/>
         <xs:attribute name='object' type='xs:string' use='required'/>
         <xs:attribute name='field' type='xs:string' use='required'/>
-        <xs:attribute name='type' type='xs:string' use='required'/>
+        <xs:attribute name='type' type='xs:string' use='optional'/>
     </xs:complexType>
 
     <!--


### PR DESCRIPTION
Solves the following error on composer update:

```
[Symfony\Component\Debug\Exception\ContextErrorException]                                                                                                                             
  User Warning: Line 45: Element 'inverse-reference', attribute 'type': The attribute 'type' is not allowed."
```